### PR TITLE
Change parquet compression

### DIFF
--- a/fiboa_cli/convert_utils.py
+++ b/fiboa_cli/convert_utils.py
@@ -26,7 +26,7 @@ def convert(
         attribution = None,
         store_collection = False,
         license = None,
-        compression = "brotli",
+        compression = "zstd",
         **kwargs):
     """
     Converts a German field boundary datasets to fiboa.

--- a/fiboa_cli/parquet.py
+++ b/fiboa_cli/parquet.py
@@ -8,7 +8,7 @@ from .types import get_geopandas_dtype, get_pyarrow_type_for_geopandas, get_pyar
 from .util import log, load_fiboa_schema, load_file, merge_schemas
 from .geopandas import to_parquet
 
-def create_parquet(data, columns, collection, output_file, config, missing_schemas = {}, compression = "brotli"):
+def create_parquet(data, columns, collection, output_file, config, missing_schemas = {}, compression = "zstd"):
     # Load the data schema
     fiboa_schema = load_fiboa_schema(config)
     schemas = merge_schemas(missing_schemas, fiboa_schema)


### PR DESCRIPTION
Changed default compression from brotli to zstd. This enables the output to work by default with DuckDB, which is a decently important target.

Closes #29 