### PR TITLE
Add ability to read parquet files directly with geopandas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- `fiboa convert`: Added step that allows to set constant values (`ADD_COLUMNS`)
+- `fiboa convert`:
+  - Added step that allows to set constant values (`ADD_COLUMNS`)
+  - Support for reading GeoParquet files
 
 ### Changed
 

--- a/fiboa_cli/convert_utils.py
+++ b/fiboa_cli/convert_utils.py
@@ -36,7 +36,7 @@ def convert(
     path = download_file(url, cache_file)
 
     # If file is a parquet file then read with read_parquet
-    if path.endswith(".parquet"):
+    if path.endswith(".parquet") or path.endswith(".geoparquet"):
         gdf = gpd.read_parquet(path, **kwargs)
     else:
         gdf = gpd.read_file(path, **kwargs)

--- a/fiboa_cli/convert_utils.py
+++ b/fiboa_cli/convert_utils.py
@@ -35,8 +35,11 @@ def convert(
         log("Loading file from: " + url)
     path = download_file(url, cache_file)
 
-    log("Local file is at: " + path)
-    gdf = gpd.read_file(path, **kwargs)
+    # If file is a parquet file then read with read_parquet
+    if path.endswith(".parquet"):
+        gdf = gpd.read_parquet(path, **kwargs)
+    else:
+        gdf = gpd.read_file(path, **kwargs)
 
     log("Loaded into GeoDataFrame:")
     print(gdf.head())

--- a/fiboa_cli/datasets/template.py
+++ b/fiboa_cli/datasets/template.py
@@ -100,7 +100,7 @@ def convert(output_file, cache_file = None, source_coop_url = None, collection =
                       Can be used to avoid repetitive downloads from the original data source.
     source_coop_url (str): URL to the (future) Source Cooperative repository. Default: None
     collection (bool): Additionally, store the collection separate from Parquet file. Default: False
-    kwargs: Additional keyword arguments for GeoPandas read_file() function.
+    kwargs: Additional keyword arguments for GeoPanda's read_file() or read_parquet() function.
     """
     convert_(
         output_file,


### PR DESCRIPTION
Added code to check if a file ends with .parquet and if so then uses the [read_parquet](https://geopandas.org/en/stable/docs/reference/api/geopandas.read_parquet.html) method instead of using fiona (which likely won't have parquet reading).

Closes #32 