### PR TITLE
initial attempt at planet data converter

### DIFF
--- a/fiboa_cli/datasets/planet_afb.py
+++ b/fiboa_cli/datasets/planet_afb.py
@@ -7,13 +7,19 @@ import re
 SOURCES = None
 
 DATA_ACCESS = """
-Get the data from Planet through ...
+Data must be obtained from the Planet subscriptions API, see 
+https://developers.planet.com/docs/planetary-variables/field-boundaries/ for additional information.
+The output should look something like FIELD_BOUNDARIES_v1.0.0_S2_P1M-20230101T000000Z_fb.gpkg
 """
 
 ID = "planet_afb"
 SHORT_NAME = "Planet Field Boundaries"
 TITLE = "Field boundaries created by Planet's Automated Field Boundary detection algorithm"
-DESCRIPTION = "These field boundaries were originally created by Planet's automated field boundary detection algorithm, and converted to the fiboa format."
+DESCRIPTION = """
+These field boundaries are created by Planet Labs, using an automated process using satellite imagery. The algorithm
+works on a monthly basis and is available for the entire globe. The data is provided in GeoPackage format.
+For more information see the [field boundaries technical specification](https://planet.widen.net/s/5vq8w5wjvf/2403.08_mar-9444-field-boundaries-technical-specification-sheet-3)
+"""
 
 PROVIDER_NAME = "Planet Labs, PBC"
 PROVIDER_URL = "https://planet.com"
@@ -34,6 +40,10 @@ COLUMNS = {
     "ca_ratio": "ca_ratio", #custom field for Planet
     "micd": "micd", #custom field for Planet
     "qa": "qa", #custom field for Planet
+}
+
+ADD_COLUMNS = {
+  "determination_method": "auto-imagery"
 }
 
 EXTENSIONS = []
@@ -81,6 +91,7 @@ def convert(output_file, input_files = None, cache = None, source_coop_url = Non
         source_coop_url=source_coop_url,
         extensions=EXTENSIONS,
         missing_schemas=MISSING_SCHEMAS,
+        column_additions=ADD_COLUMNS,
         file_migration=FILE_MIGRATION,
         attribution=ATTRIBUTION,
         store_collection=collection,

--- a/fiboa_cli/datasets/planet_afb.py
+++ b/fiboa_cli/datasets/planet_afb.py
@@ -1,0 +1,144 @@
+# Converter for geopackage output of Planet's Field Boundaries dataset.
+
+from ..convert_utils import convert as convert_
+
+# This local path should not be the main way this converter work. When there's some open data
+# we could point at that, but the ideal way this converter should work is by letting the user pass
+# in a local or remote path that is produced by Planet's field boundary output, converting 
+# whatever data is in it into fiboa. Not sure how to do that yet, seems like a -i flag could work
+# to complement -o, and then perhaps allow this converter to make it required? Or it could
+# default to an open dataset, but then have -i override (and check to make sure it matches)
+SOURCES = "/Users/cholmes/repos/data-fiboa/source/FIELD_BOUNDARIES_v1.0.0_S2_P1M-20230101T000000Z_fb.gpkg"
+
+# Unique identifier for the collection
+ID = "planet_afb"
+# Title of the collection
+TITLE = "Field boundaries created by Planet's Automated Field Boundary detection algorithm."
+# Description of the collection. Can be multiline and include CommonMark.
+DESCRIPTION = "These field boundaries were originally created by Planet's automated field boundary detection algorithm, and converted to the fiboa format."
+
+# Provider name, can be None if not applicable, must be provided if PROVIDER_URL is provided
+PROVIDER_NAME = "Planet Labs, PBC"
+# URL to the homepage of the data or the provider, can be None if not applicable
+PROVIDER_URL = "https://planet.com"
+# Attribution, can be None if not applicable
+ATTRIBUTION = "© 2024 Planet Labs, PBC"
+
+# License of the data, either
+# 1. a SPDX license identifier (including "dl-de/by-2-0" / "dl-de/zero-2-0"), or
+# LICENSE = "CC-BY-4.0"
+# 2. a STAC Link Object with relation type "license"
+LICENSE = {"title": "Proprietary", "href": "https://www.planet.com/licensing-information/", "type": "text/html", "rel": "license"}
+
+# Map original column names to fiboa property names
+# You also need to list any column that you may have added in the MIGRATION function (see below).
+COLUMNS = {
+    "polygon_id": "id", #fiboa core field
+    "area_ha": "area", #fiboa core field
+    "geometry": "geometry", #fiboa core field
+    "ca_ratio": "ca_ratio", #custom field for Planet
+    "micd": "micd", #custom field for Planet
+    "qa": "qa", #custom field for Planet
+}
+
+# Add columns with constant values.
+# The key is the column name, the value is a constant value that's used for all rows.
+ADD_COLUMNS = {
+    # Hardcoding for this particular dataset, but Planet currently does not have a date column,
+    # but does include the date in the filename. So not sure if there's a way to pull the date
+    # from the filename? I suppose not now when there's no way to pass in the file name...
+    "determination_datetime": "2023-01-01T00:00:00Z"
+}
+
+# A list of implemented extension identifiers
+EXTENSIONS = []
+
+# Functions to migrate data in columns to match the fiboa specification.
+# Example: You have a column area_m in square meters and want to convert
+# to hectares as required for the area field in fiboa.
+# Function signature:
+#   func(column: pd.Series) -> pd.Series
+COLUMN_MIGRATIONS = {
+}
+
+# Filter columns to only include the ones that are relevant for the collection,
+# e.g. only rows that contain the word "agriculture" but not "forest" in the column "land_cover_type".
+# Lamda function accepts a Pandas Series and returns a Series or a Tuple with a Series and True to inverse the mask.
+COLUMN_FILTERS = {
+}
+
+# Custom function to migrate the GeoDataFrame if the other options are not sufficient
+# This should be the last resort!
+# Function signature:
+#   func(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame
+MIGRATION = None
+
+# Schemas for the fields that are not defined in fiboa
+# Keys must be the values from the COLUMNS dict, not the keys
+MISSING_SCHEMAS = {
+    "required": ["ca_ratio", "micd", "qa" ], # i.e. non-nullable properties
+    "properties": {
+        "ca_ratio": {
+            "type": "float"
+        },
+        "micd": {
+            "type": "float"
+        },
+        "qa": {
+            "type": "uint8"
+        }
+    }
+}
+
+
+# Conversion function, usually no changes required
+def convert(output_file, cache = None, source_coop_url = None, collection = False, compression = None):
+    """
+    Converts the field boundary datasets to fiboa.
+
+    For reference, this is the order in which the conversion steps are applied:
+    0. Read GeoDataFrame from file
+    1. Run global migration (if provided through MIGRATION)
+    2. Run filters to remove rows that shall not be in the final data
+       (if provided through COLUMN_FILTERS)
+    3. Add columns with constant values
+    4. Run column migrations (if provided through COLUMN_MIGRATIONS)
+    5. Duplicate columns (if an array is provided as the value in COLUMNS)
+    6. Rename columns (as provided in COLUMNS)
+    7. Remove columns (if column is not present as value in COLUMNS)
+    8. Create the collection
+    9. Change data types of the columns based on the provided schemas
+    (fiboa spec, extensions, and MISSING_SCHEMAS)
+    10. Write the data to the Parquet file
+
+    Parameters:
+    output_file (str): Path where the Parquet file shall be stored.
+    cache (str): Path to a cached folder for the data. Default: None.
+                      Can be used to avoid repetitive downloads from the original data source.
+    source_coop_url (str): URL to the (future) Source Cooperative repository. Default: None
+    collection (bool): Additionally, store the collection separate from Parquet file. Default: False
+    compression (str): Compression method for the Parquet file. Default: zstd
+    kwargs: Additional keyword arguments for GeoPanda's read_file() or read_parquet() function.
+    """
+    convert_(
+        output_file,
+        cache,
+        SOURCES,
+        COLUMNS,
+        ID,
+        TITLE,
+        DESCRIPTION,
+        provider_name=PROVIDER_NAME,
+        provider_url=PROVIDER_URL,
+        source_coop_url=source_coop_url,
+        extensions=EXTENSIONS,
+        missing_schemas=MISSING_SCHEMAS,
+        column_additions=ADD_COLUMNS,
+        column_migrations=COLUMN_MIGRATIONS,
+        column_filters=COLUMN_FILTERS,
+        migration=MIGRATION,
+        attribution=ATTRIBUTION,
+        store_collection=collection,
+        license=LICENSE,
+        compression=compression,
+    )

--- a/fiboa_cli/datasets/planet_afb.py
+++ b/fiboa_cli/datasets/planet_afb.py
@@ -4,7 +4,7 @@ from ..convert_utils import convert as convert_
 
 # This local path should not be the main way this converter work. When there's some open data
 # we could point at that, but the ideal way this converter should work is by letting the user pass
-# in a local or remote path that is produced by Planet's field boundary output, converting 
+# in a local or remote path that is produced by Planet's field boundary output, converting
 # whatever data is in it into fiboa. Not sure how to do that yet, seems like a -i flag could work
 # to complement -o, and then perhaps allow this converter to make it required? Or it could
 # default to an open dataset, but then have -i override (and check to make sure it matches)
@@ -12,8 +12,10 @@ SOURCES = "/Users/cholmes/repos/data-fiboa/source/FIELD_BOUNDARIES_v1.0.0_S2_P1M
 
 # Unique identifier for the collection
 ID = "planet_afb"
+# Geonames for the data (e.g. Country, Region, Source, Year)
+SHORT_NAME = "Planet Field Boundaries"
 # Title of the collection
-TITLE = "Field boundaries created by Planet's Automated Field Boundary detection algorithm."
+TITLE = "Field boundaries created by Planet's Automated Field Boundary detection algorithm"
 # Description of the collection. Can be multiline and include CommonMark.
 DESCRIPTION = "These field boundaries were originally created by Planet's automated field boundary detection algorithm, and converted to the fiboa format."
 
@@ -28,7 +30,7 @@ ATTRIBUTION = "© 2024 Planet Labs, PBC"
 # 1. a SPDX license identifier (including "dl-de/by-2-0" / "dl-de/zero-2-0"), or
 # LICENSE = "CC-BY-4.0"
 # 2. a STAC Link Object with relation type "license"
-LICENSE = {"title": "Proprietary", "href": "https://www.planet.com/licensing-information/", "type": "text/html", "rel": "license"}
+LICENSE = {"title": "Proprietary License", "href": "https://www.planet.com/licensing-information/", "type": "text/html", "rel": "license"}
 
 # Map original column names to fiboa property names
 # You also need to list any column that you may have added in the MIGRATION function (see below).
@@ -47,7 +49,7 @@ ADD_COLUMNS = {
     # Hardcoding for this particular dataset, but Planet currently does not have a date column,
     # but does include the date in the filename. So not sure if there's a way to pull the date
     # from the filename? I suppose not now when there's no way to pass in the file name...
-    "determination_datetime": "2023-01-01T00:00:00Z"
+    # "determination_datetime": "2023-01-01T00:00:00Z"
 }
 
 # A list of implemented extension identifiers

--- a/fiboa_cli/datasets/planet_afb.py
+++ b/fiboa_cli/datasets/planet_afb.py
@@ -1,84 +1,57 @@
 # Converter for geopackage output of Planet's Field Boundaries dataset.
 
 from ..convert_utils import convert as convert_
+import os
+import re
 
-# This local path should not be the main way this converter work. When there's some open data
-# we could point at that, but the ideal way this converter should work is by letting the user pass
-# in a local or remote path that is produced by Planet's field boundary output, converting
-# whatever data is in it into fiboa. Not sure how to do that yet, seems like a -i flag could work
-# to complement -o, and then perhaps allow this converter to make it required? Or it could
-# default to an open dataset, but then have -i override (and check to make sure it matches)
-SOURCES = "/Users/cholmes/repos/data-fiboa/source/FIELD_BOUNDARIES_v1.0.0_S2_P1M-20230101T000000Z_fb.gpkg"
+SOURCES = None
 
-# Unique identifier for the collection
+DATA_ACCESS = """
+Get the data from Planet through ...
+"""
+
 ID = "planet_afb"
-# Geonames for the data (e.g. Country, Region, Source, Year)
 SHORT_NAME = "Planet Field Boundaries"
-# Title of the collection
 TITLE = "Field boundaries created by Planet's Automated Field Boundary detection algorithm"
-# Description of the collection. Can be multiline and include CommonMark.
 DESCRIPTION = "These field boundaries were originally created by Planet's automated field boundary detection algorithm, and converted to the fiboa format."
 
-# Provider name, can be None if not applicable, must be provided if PROVIDER_URL is provided
 PROVIDER_NAME = "Planet Labs, PBC"
-# URL to the homepage of the data or the provider, can be None if not applicable
 PROVIDER_URL = "https://planet.com"
-# Attribution, can be None if not applicable
 ATTRIBUTION = "© 2024 Planet Labs, PBC"
 
-# License of the data, either
-# 1. a SPDX license identifier (including "dl-de/by-2-0" / "dl-de/zero-2-0"), or
-# LICENSE = "CC-BY-4.0"
-# 2. a STAC Link Object with relation type "license"
-LICENSE = {"title": "Proprietary License", "href": "https://www.planet.com/licensing-information/", "type": "text/html", "rel": "license"}
+LICENSE = {
+    "title": "Proprietary License",
+    "href": "https://www.planet.com/licensing-information/",
+    "type": "text/html",
+    "rel": "license"
+}
 
-# Map original column names to fiboa property names
-# You also need to list any column that you may have added in the MIGRATION function (see below).
 COLUMNS = {
     "polygon_id": "id", #fiboa core field
     "area_ha": "area", #fiboa core field
     "geometry": "geometry", #fiboa core field
+    "determination_datetime": "determination_datetime", #fiboa core field
     "ca_ratio": "ca_ratio", #custom field for Planet
     "micd": "micd", #custom field for Planet
     "qa": "qa", #custom field for Planet
 }
 
-# Add columns with constant values.
-# The key is the column name, the value is a constant value that's used for all rows.
-ADD_COLUMNS = {
-    # Hardcoding for this particular dataset, but Planet currently does not have a date column,
-    # but does include the date in the filename. So not sure if there's a way to pull the date
-    # from the filename? I suppose not now when there's no way to pass in the file name...
-    # "determination_datetime": "2023-01-01T00:00:00Z"
-}
-
-# A list of implemented extension identifiers
 EXTENSIONS = []
 
-# Functions to migrate data in columns to match the fiboa specification.
-# Example: You have a column area_m in square meters and want to convert
-# to hectares as required for the area field in fiboa.
-# Function signature:
-#   func(column: pd.Series) -> pd.Series
-COLUMN_MIGRATIONS = {
-}
+def FILE_MIGRATION(gdf, path, uri):
+    # The file name contains the date, so we can use that to add a
+    # date column to the dataset.
+    # Assumed filename:
+    # FIELD_BOUNDARIES_v1.0.0_S2_P1M-20230101T000000Z_fb.gpkg
+    name = os.path.basename(path)
+    matches = re.search(r"-(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z_fb.gpkg$", name)
+    if matches:
+        dt = matches.groups()
+        gdf["determination_datetime"] = f"{dt[0]}-{dt[1]}-{dt[2]}T{dt[3]}:{dt[4]}:{dt[5]}Z"
+    return gdf
 
-# Filter columns to only include the ones that are relevant for the collection,
-# e.g. only rows that contain the word "agriculture" but not "forest" in the column "land_cover_type".
-# Lamda function accepts a Pandas Series and returns a Series or a Tuple with a Series and True to inverse the mask.
-COLUMN_FILTERS = {
-}
-
-# Custom function to migrate the GeoDataFrame if the other options are not sufficient
-# This should be the last resort!
-# Function signature:
-#   func(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame
-MIGRATION = None
-
-# Schemas for the fields that are not defined in fiboa
-# Keys must be the values from the COLUMNS dict, not the keys
 MISSING_SCHEMAS = {
-    "required": ["ca_ratio", "micd", "qa" ], # i.e. non-nullable properties
+    "required": ["ca_ratio", "micd", "qa"], # i.e. non-nullable properties
     "properties": {
         "ca_ratio": {
             "type": "float"
@@ -93,35 +66,7 @@ MISSING_SCHEMAS = {
 }
 
 
-# Conversion function, usually no changes required
-def convert(output_file, cache = None, source_coop_url = None, collection = False, compression = None):
-    """
-    Converts the field boundary datasets to fiboa.
-
-    For reference, this is the order in which the conversion steps are applied:
-    0. Read GeoDataFrame from file
-    1. Run global migration (if provided through MIGRATION)
-    2. Run filters to remove rows that shall not be in the final data
-       (if provided through COLUMN_FILTERS)
-    3. Add columns with constant values
-    4. Run column migrations (if provided through COLUMN_MIGRATIONS)
-    5. Duplicate columns (if an array is provided as the value in COLUMNS)
-    6. Rename columns (as provided in COLUMNS)
-    7. Remove columns (if column is not present as value in COLUMNS)
-    8. Create the collection
-    9. Change data types of the columns based on the provided schemas
-    (fiboa spec, extensions, and MISSING_SCHEMAS)
-    10. Write the data to the Parquet file
-
-    Parameters:
-    output_file (str): Path where the Parquet file shall be stored.
-    cache (str): Path to a cached folder for the data. Default: None.
-                      Can be used to avoid repetitive downloads from the original data source.
-    source_coop_url (str): URL to the (future) Source Cooperative repository. Default: None
-    collection (bool): Additionally, store the collection separate from Parquet file. Default: False
-    compression (str): Compression method for the Parquet file. Default: zstd
-    kwargs: Additional keyword arguments for GeoPanda's read_file() or read_parquet() function.
-    """
+def convert(output_file, input_files = None, cache = None, source_coop_url = None, collection = False, compression = None):
     convert_(
         output_file,
         cache,
@@ -130,15 +75,13 @@ def convert(output_file, cache = None, source_coop_url = None, collection = Fals
         ID,
         TITLE,
         DESCRIPTION,
+        input_files=input_files,
         provider_name=PROVIDER_NAME,
         provider_url=PROVIDER_URL,
         source_coop_url=source_coop_url,
         extensions=EXTENSIONS,
         missing_schemas=MISSING_SCHEMAS,
-        column_additions=ADD_COLUMNS,
-        column_migrations=COLUMN_MIGRATIONS,
-        column_filters=COLUMN_FILTERS,
-        migration=MIGRATION,
+        file_migration=FILE_MIGRATION,
         attribution=ATTRIBUTION,
         store_collection=collection,
         license=LICENSE,


### PR DESCRIPTION
This one needs a bit of help, but I think is pretty close.

I got it mostly working, though couldn't figure out why it was using 0.4.0 of the CLI, until I pushed the branch and realized I'd accidentally branched off of the Austria and Brazil converter branch that I was investigating. But I had managed to get it working locally.

Then I switched to 0.5.0, pleased to remove my dummy 'bbox' that I stuck in, but it's now stuck. I get:

```
% fiboa convert planet_afb -o ~/repos/data-fiboa/output/planet.parquet
fiboa CLI 0.5.0 - Convert 'planet_afb'

Getting file(s) if not cached yet
'dict' object has no attribute 'delete'
```

I couldn't find where the 'delete' was coming from, or where it should be. Any ideas? 

This PR also raises some issues, I mostly highlighted as comments in the code, the main one being that this is not about converted a fixed, online dataset, but is meant to be a tool to converter any Planet field boundary output. So it'd ideally have like a `-i` flag to point at a file instead of a default online location, or even require an input argument for this conversion. So curious how to approach this. It will be similar for DigiFarm and OneSoil, two other converters I'd like to make, as those are the three main field boundary providers that I know of.

