### PR TITLE
updates to planet converter to use the planet fiboa extension

### DIFF
--- a/fiboa_cli/datasets/planet_afb.py
+++ b/fiboa_cli/datasets/planet_afb.py
@@ -55,8 +55,6 @@ ADD_COLUMNS = {
   "determination_method": "auto-imagery"
 }
 
-EXTENSIONS = []
-
 def FILE_MIGRATION(gdf, path, uri, layer = None):
     # The file name contains the date, so we can use that to add a
     # date column to the dataset.

--- a/fiboa_cli/datasets/planet_afb.py
+++ b/fiboa_cli/datasets/planet_afb.py
@@ -37,14 +37,18 @@ LICENSE = {
     "rel": "license"
 }
 
+EXTENSIONS = [
+    "https://fiboa.github.io/planet-extension/v0.1.0/schema.yaml"
+]
+
 COLUMNS = {
     "polygon_id": "id", #fiboa core field
     "area_ha": "area", #fiboa core field
     "geometry": "geometry", #fiboa core field
     "determination_datetime": "determination_datetime", #fiboa core field
-    "ca_ratio": "ca_ratio", #custom field for Planet
-    "micd": "micd", #custom field for Planet
-    "qa": "qa", #custom field for Planet
+    "ca_ratio": "planet:ca_ratio", #From Planet extension for fiboa
+    "micd": "planet:micd", #From Planet extension for fiboa 
+    "qa": "planet:qa", #From Planet extension for fiboa
 }
 
 ADD_COLUMNS = {
@@ -66,18 +70,6 @@ def FILE_MIGRATION(gdf, path, uri, layer = None):
     return gdf
 
 MISSING_SCHEMAS = {
-    "required": ["ca_ratio", "micd", "qa"], # i.e. non-nullable properties
-    "properties": {
-        "ca_ratio": {
-            "type": "float"
-        },
-        "micd": {
-            "type": "float"
-        },
-        "qa": {
-            "type": "uint8"
-        }
-    }
 }
 
 


### PR DESCRIPTION
Updated the planet_afb converter to try to use the extension. It seems to mostly work, but I get 

```
planet:ca_ratio: No schema defined, converting float64 to nullable double
planet:micd: No schema defined, converting float64 to nullable double
planet:qa: No schema defined, converting int64 to nullable int64
```

when I run the conversion - `fiboa convert planet_afb -i ~/repos/data-fiboa/source/FIELD_BOUNDARIES_v1.0.0_S2_P1M-20230101T000000Z_fb.gpkg -o ~/Downloads/updated-planet-fiboa.parquet`

It seems to use the extension at least in some way, but then doesn't seem to pick up what types to use? I probably missed something I'm supposed to tweak - help appreciated.
