### PR TITLE
Change Parquet row group size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - `fiboa convert`: Default compression changed from `zstd` to `brotli`
+- The default row group size of exported parquet files was changed from ~1.000.000 to 25.000
 
 ## [v0.7.0] - 2024-08-24
 

--- a/fiboa_cli/parquet.py
+++ b/fiboa_cli/parquet.py
@@ -8,6 +8,8 @@ from .types import get_geopandas_dtype, get_pyarrow_type_for_geopandas, get_pyar
 from .util import log, load_fiboa_schema, load_file, merge_schemas
 from .geopandas import to_parquet
 
+ROW_GROUP_SIZE = 25000
+
 def create_parquet(data, columns, collection, output_file, config, missing_schemas = {}, compression = None, geoparquet1 = False):
     # Load the data schema
     fiboa_schema = load_fiboa_schema(config)
@@ -81,6 +83,7 @@ def create_parquet(data, columns, collection, output_file, config, missing_schem
         coerce_timestamps = "ms",
         compression = compression,
         schema_version = "1.0.0" if geoparquet1 else "1.1.0",
+        row_group_size = ROW_GROUP_SIZE,
         write_covering_bbox = False if geoparquet1 else True
     )
 


### PR DESCRIPTION
The default row group size of exported parquet files was changed from ~1.000.000 to 25.000