### PR TITLE
Set click dependency to fixed version click==8.1.8 #163

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "pyyaml>=6.0",
         "pyarrow>=14.0",
         "fsspec>=2024.0",
-        "click>=8.1",
+        "click==8.1.8",
         "geopandas>=1.0.0",
         "requests>=2.30",
         "aiohttp>=3.9",


### PR DESCRIPTION
See discussion https://github.com/fiboa/cli/pull/160#discussion_r2094595082

Some test fail if click is upgraded to the click==8.2.0 (released last week)

This solves https://github.com/fiboa/cli/issues/163