### PR TITLE
Rename variants to years

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Check proper 2-letter country-id for admin-extension
 - Converter for JECAM datasets 
 - Converter for Romania, based on LandCover dataset
+- Replace BaseConverter.source_variants by years
 
 ## [v0.10.0] - 2025-03-11
 

--- a/fiboa_cli/convert_utils.py
+++ b/fiboa_cli/convert_utils.py
@@ -170,8 +170,6 @@ class BaseConverter:
     providers: list[dict] = []
 
     sources: Optional[dict[str, str] | str] = None
-    source_variants: Optional[dict[dict[str, str] | str]] = None
-    variant: str = None
     open_options = {}
     years: Optional[dict[dict[int, str] | str]] = None
     year: str = None

--- a/fiboa_cli/converter_rest_pregenerate.py
+++ b/fiboa_cli/converter_rest_pregenerate.py
@@ -25,6 +25,6 @@ class EsriRESTPregenerateConverterMixin:
 
         get_dict = self.rest_params | {"outFields": "*", "returnGeometry": "true", "f": "geojson"}
         return {
-            f"{layer_url}?{urlencode(get_dict | dict(resultRecordCount=page_size, resultOffset=page_size * page))}": f"{self.id}_{self.variant or ''}_{page}.json"
+            f"{layer_url}?{urlencode(get_dict | dict(resultRecordCount=page_size, resultOffset=page_size * page))}": f"{self.id}_{self.year or ''}_{page}.json"
             for page in range(nr_pages)
         }

--- a/fiboa_cli/datasets/es_an.py
+++ b/fiboa_cli/datasets/es_an.py
@@ -6,7 +6,7 @@ from .es import ESBaseConverter
 
 
 class ANConverter(ESBaseConverter):
-    source_variants = {
+    years = {
         "2024": "https://www.juntadeandalucia.es/ssdigitales/festa/agriculturapescaaguaydesarrollorural/2024/SP24_REC_{code}.zip",
         "2023": "https://www.juntadeandalucia.es/ssdigitales/festa/agriculturapescaaguaydesarrollorural/2023/SP23_REC_{code}.zip",
         "2022": "https://www.juntadeandalucia.es/export/drupaljda/01_SP22_REC_PROV_{code}.zip",
@@ -76,16 +76,16 @@ class ANConverter(ESBaseConverter):
     }
 
     def get_urls(self):
-        if not self.variant:
-            self.variant = next(iter(self.source_variants))
-            log(f"Choosing first variant {self.variant}", "warning")
+        if not self.year:
+            self.year = next(iter(self.years))
+            log(f"Choosing first year {self.year}", "warning")
         else:
-            assert self.variant in self.source_variants, f"Wrong variant {self.variant}"
+            assert self.year in self.years, f"Wrong year {self.year}"
 
-        url = self.source_variants[self.variant]
+        url = self.years[self.year]
         data = read_data_csv("es_an_prv.csv")
 
         def fname(line):
-            return f"SP{int(self.variant) % 100}_REC_{line['code']}.shp"
+            return f"SP{int(self.year) % 100}_REC_{line['code']}.shp"
 
         return {url.format(**line): [fname(line)] for line in data}

--- a/fiboa_cli/datasets/es_cat.py
+++ b/fiboa_cli/datasets/es_cat.py
@@ -6,7 +6,12 @@ from .commons.data import read_data_csv
 
 class ESCatConverter(BaseConverter):
     # Catalonia has its own coding list, not sublass of ESBaseConverter
-    source_variants = {
+    years = {
+        "2024": {
+            "https://analisi.transparenciacatalunya.cat/api/views/yh94-j2n9/files/d90f5fca-ddd8-405d-a0d5-90609985e98e?download=true&filename=Cultius_DUN2024_SHP.zip": [
+                "Cultius_DUN2024_GPKG/CULTIUS_DUN2024.gpkg"
+            ]
+        },
         "2023": {
             "https://analisi.transparenciacatalunya.cat/api/views/yh94-j2n9/files/b4299961-52ee-4fa0-a276-4594c8c094bc?download=true&filename=Cultius_DUN2023_GPKG.zip": [
                 "Cultius_DUN2023_GPKG/CULTIUS_DUN2023.gpkg"

--- a/fiboa_cli/datasets/es_cb.py
+++ b/fiboa_cli/datasets/es_cb.py
@@ -39,7 +39,7 @@ class ESCBConverter(EsriRESTConverterMixin, ESBaseConverter):
         }
     }
 
-    source_variants = {str(year): str(year) for year in range(2024, 2010 - 1, -1)}
+    years = {str(year): str(year) for year in range(2024, 2010 - 1, -1)}
     use_code_attribute = "USO_SIGPAC"
 
     # "https://geoservicios.cantabria.es/inspire/rest/services/SIGPAC/MapServer?f=json"
@@ -49,8 +49,8 @@ class ESCBConverter(EsriRESTConverterMixin, ESBaseConverter):
     # rest_params = {"where": "USO_SIGPAC NOT IN ('AG','CA','ED','FO','IM','IS','IV','TH','ZC','ZU','ZV','MT')"}
 
     def rest_layer_filter(self, layers):
-        if not self.variant:
-            self.variant = next(iter(self.source_variants))
+        if not self.year:
+            self.year = next(iter(self.years))
         self.column_additions["determination_datetime"] = ""
-        regex = re.compile("Recintos SIGPAC " + self.variant)
+        regex = re.compile("Recintos SIGPAC " + self.year)
         return next(layer for layer in layers if regex.match(layer["name"]))

--- a/fiboa_cli/datasets/es_cl.py
+++ b/fiboa_cli/datasets/es_cl.py
@@ -61,14 +61,12 @@ class ESCLConverter(ESBaseConverter):
         return new
 
     def get_urls(self):
-        if not self.variant:
-            self.variant = "2024"
-            log(f"Choosing first variant {self.variant}", "warning")
+        if not self.year:
+            self.year = "2024"
+            log(f"Choosing first year {self.year}", "warning")
         else:
-            assert self.variant in "2024 2023 2022 2021 2020 2019".split(), (
-                f"Wrong variant {self.variant}"
-            )
-        base = f"http://ftp.itacyl.es/cartografia/05_SIGPAC/{self.variant}_ETRS89/Parcelario_SIGPAC_CyL_Provincias/"
+            assert self.year in "2024 2023 2022 2021 2020 2019".split(), f"Wrong year {self.year}"
+        base = f"http://ftp.itacyl.es/cartografia/05_SIGPAC/{self.year}_ETRS89/Parcelario_SIGPAC_CyL_Provincias/"
         response = requests.get(base)
         assert response.status_code == 200, f"Error getting urls {response}\n{response.content}"
         uris = {

--- a/fiboa_cli/datasets/es_cm.py
+++ b/fiboa_cli/datasets/es_cm.py
@@ -42,22 +42,22 @@ class ESCMConverter(EsriRESTConverterMixin, ESBaseConverter):
             "admin_municipality_code": {"type": "string"},
         }
     }
-    source_variants = {str(year): str(year) for year in range(2024, 2018 - 1, -1)}
+    years = {str(year): str(year) for year in range(2024, 2018 - 1, -1)}
 
     rest_base_url = "https://geoservicios.castillalamancha.es/arcgis/rest/services/Vector"
     rest_attribute = "objectid_1"
 
     def get_urls(self):
-        latest_variant = next(iter(self.source_variants))
-        if not self.variant:
-            self.variant = latest_variant
-        if self.variant == latest_variant:
+        latest_year = next(iter(self.years))
+        if not self.year:
+            self.year = latest_year
+        if self.year == latest_year:
             layer = "Vector/Recintos_sigpac"
         else:
             services = requests.get(self.rest_base_url, {"f": "pjson"}).json()["services"]
             layer = next(
                 s["name"]
                 for s in services
-                if re.search(f"Recintos_sigpac_{self.variant}", s["name"], re.IGNORECASE)
+                if re.search(f"Recintos_sigpac_{self.year}", s["name"], re.IGNORECASE)
             )
         return {"REST": self.rest_base_url.replace("Vector", layer + "/MapServer")}

--- a/fiboa_cli/datasets/es_ex.py
+++ b/fiboa_cli/datasets/es_ex.py
@@ -38,7 +38,7 @@ class EXConverter(ESBaseConverter):
 
     def migrate(self, gdf):
         gdf = super().migrate(gdf)
-        gdf["determination_datetime"] = datetime(year=int(self.variant), month=1, day=1)
+        gdf["determination_datetime"] = datetime(year=int(self.year), month=1, day=1)
         return gdf
 
     missing_schemas = {
@@ -47,11 +47,11 @@ class EXConverter(ESBaseConverter):
             "admin_municipality_code": {"type": "string"},
         }
     }
-    source_variants = {"2024": "TODO", "2023": "TODO"}
+    years = {"2024": "TODO", "2023": "TODO"}
 
     def get_urls(self):
-        if not self.variant:
-            self.variant = next(iter(self.source_variants))
+        if not self.year:
+            self.year = next(iter(self.years))
 
         from bs4 import BeautifulSoup
 
@@ -74,6 +74,6 @@ class EXConverter(ESBaseConverter):
             response = requests.post(f"{base}listadoresultados", data=form, headers=headers)
             soup = BeautifulSoup(response.content, "html.parser")
             matches = soup.find_all("a", href=re.compile(r"/SITEX/centrodescargas/descargar/"))
-            m = matches[1 if self.variant == "2023" else 0].get("href")
+            m = matches[1 if self.year == "2023" else 0].get("href")
             result[f"http://sitex.gobex.es/{m}"] = ["*.shp"]  # The single shapefile
         return result

--- a/fiboa_cli/datasets/es_ga.py
+++ b/fiboa_cli/datasets/es_ga.py
@@ -40,15 +40,17 @@ class ESGAConverter(EsriRESTConverterMixin, ESBaseConverter):
         }
     }
 
-    source_variants = {str(year): str(year) for year in range(2024, 2010 - 1, -1)}
+    years = {str(year): str(year) for year in range(2024, 2010 - 1, -1)}
     use_code_attribute = "USO_SIGPAC"
 
-    rest_base_url = "https://ideg.xunta.gal/servizos/rest/services/ParcelasCatastrais/SIXPAC_{variant}/MapServer"
+    rest_base_url = (
+        "https://ideg.xunta.gal/servizos/rest/services/ParcelasCatastrais/SIXPAC_{year}/MapServer"
+    )
 
     def rest_layer_filter(self, layers):
         return next(layer for layer in layers if "recintos" in layer["name"].lower())
 
     def get_urls(self):
-        if not self.variant:
-            self.variant = next(iter(self.source_variants))
-        return {"REST": self.rest_base_url.format(variant=self.variant)}
+        if not self.year:
+            self.year = next(iter(self.years))
+        return {"REST": self.rest_base_url.format(year=self.year)}

--- a/fiboa_cli/datasets/es_ib.py
+++ b/fiboa_cli/datasets/es_ib.py
@@ -46,8 +46,8 @@ class ESIBConverter(EsriRESTConverterMixin, ESBaseConverter):
         }
     }
 
-    # See https://ideib.caib.es/geoserveis/rest/services/public/GOIB_SIGPAC_IB/MapServer/ for current variants
-    source_variants = {str(year): str(year) for year in range(2024, 2010 - 1, -1)}
+    # See https://ideib.caib.es/geoserveis/rest/services/public/GOIB_SIGPAC_IB/MapServer/ for current years
+    years = {str(year): str(year) for year in range(2024, 2010 - 1, -1)}
     use_code_attribute = "USO_SIGPAC"
 
     rest_base_url = "https://ideib.caib.es/geoserveis/rest/services/public/GOIB_SIGPAC_IB/MapServer"
@@ -56,7 +56,7 @@ class ESIBConverter(EsriRESTConverterMixin, ESBaseConverter):
     }
 
     def rest_layer_filter(self, layers):
-        if not self.variant:
-            self.variant = next(iter(self.source_variants))
-        regex = re.compile("SIGPAC .* " + self.variant)
+        if not self.year:
+            self.year = next(iter(self.years))
+        regex = re.compile("SIGPAC .* " + self.year)
         return next(layer for layer in layers if regex.match(layer["name"]))

--- a/fiboa_cli/datasets/es_pv.py
+++ b/fiboa_cli/datasets/es_pv.py
@@ -6,7 +6,7 @@ from .es import ESBaseConverter
 
 
 class ESPVConverter(ESBaseConverter):
-    source_variants = {
+    years = {
         str(
             year
         ): f"https://www.geo.euskadi.eus/cartografia/DatosDescarga/Agricultura/SIGPAC/SIGPAC_CAMPA%C3%91A_{year}_V1/"
@@ -44,19 +44,17 @@ class ESPVConverter(ESBaseConverter):
     index_as_id = True
 
     def get_urls(self):
-        if not self.variant:
-            self.variant = "2024"
-            log(f"Choosing first variant {self.variant}", "warning")
+        if not self.year:
+            self.year = "2024"
+            log(f"Choosing first year {self.year}", "warning")
         else:
-            assert self.variant in self.source_variants
+            assert self.year in self.years
 
         from bs4 import BeautifulSoup
 
         # Parse list of zips in two steps from source url
         host = "https://www.geo.euskadi.eus"
-        base = (
-            f"/cartografia/DatosDescarga/Agricultura/SIGPAC/SIGPAC_CAMPA%C3%91A_{self.variant}_V1/"
-        )
+        base = f"/cartografia/DatosDescarga/Agricultura/SIGPAC/SIGPAC_CAMPA%C3%91A_{self.year}_V1/"
         soup = BeautifulSoup(requests.get(f"{host}/{base}").content, "html.parser")
         pages = [p["href"] for p in soup.find_all("a") if p["href"].startswith(base)]
         parsed = [

--- a/fiboa_cli/datasets/es_vc.py
+++ b/fiboa_cli/datasets/es_vc.py
@@ -7,7 +7,7 @@ from .es import ESBaseConverter
 
 
 class ESVCConverter(ESBaseConverter):
-    source_variants = {str(year): str(year) for year in range(2024, 2016 - 1, -1)}
+    years = {str(year): str(year) for year in range(2024, 2016 - 1, -1)}
     id = "es_vc"
     short_name = "Spain Valencia"
     title = "Spain Valencia Crop Fields"
@@ -47,13 +47,13 @@ class ESVCConverter(ESBaseConverter):
     use_code_attribute = "USO_SIGPAC"
 
     def get_urls(self):
-        if not self.variant:
-            self.variant = next(iter(self.source_variants))
-        self.column_additions["determination_datetime"] = datetime(int(self.variant), 1, 1)
+        if not self.year:
+            self.year = next(iter(self.years))
+        self.column_additions["determination_datetime"] = datetime(int(self.year), 1, 1)
 
         from bs4 import BeautifulSoup
 
-        base = f"https://descargas.icv.gva.es/dcd/14_mediorural/03_pac/{self.variant}_SIGPAC_0050"
+        base = f"https://descargas.icv.gva.es/dcd/14_mediorural/03_pac/{self.year}_SIGPAC_0050"
         soup = BeautifulSoup(requests.get(f"{base}").content, "html.parser")
         result = {
             f"{base}/{e.get('href')}": ["*/RECINTO.shp"]


### PR DESCRIPTION
Harmonize code base. We agreed to use 'years' instead of 'variants'